### PR TITLE
[Feat] 사업자등록번호 진위확인 기능 구현

### DIFF
--- a/project/src/main/java/org/example/fourtreesproject/companyRegVerify/controller/CompanyRegVerifyController.java
+++ b/project/src/main/java/org/example/fourtreesproject/companyRegVerify/controller/CompanyRegVerifyController.java
@@ -1,0 +1,23 @@
+package org.example.fourtreesproject.companyRegVerify.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.RequiredArgsConstructor;
+import org.example.fourtreesproject.common.BaseResponse;
+import org.example.fourtreesproject.companyRegVerify.model.request.CompanyRegVerifyRequest;
+import org.example.fourtreesproject.companyRegVerify.service.CompanyRegVerifyService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/company-reg")
+@RequiredArgsConstructor
+public class CompanyRegVerifyController {
+    private final CompanyRegVerifyService companyRegVerifyService;
+
+    @PostMapping("/verify")
+    public BaseResponse verify(@RequestBody CompanyRegVerifyRequest companyRegVerifyRequest) {
+        return companyRegVerifyService.verify(companyRegVerifyRequest);
+    }
+}

--- a/project/src/main/java/org/example/fourtreesproject/companyRegVerify/dto/CompanyRegVeriifyDto.java
+++ b/project/src/main/java/org/example/fourtreesproject/companyRegVerify/dto/CompanyRegVeriifyDto.java
@@ -1,0 +1,12 @@
+package org.example.fourtreesproject.companyRegVerify.dto;
+
+import lombok.*;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CompanyRegVeriifyDto {
+    private String companyReg;
+    private String uuid;
+}

--- a/project/src/main/java/org/example/fourtreesproject/companyRegVerify/model/entity/CompanyRegVerify.java
+++ b/project/src/main/java/org/example/fourtreesproject/companyRegVerify/model/entity/CompanyRegVerify.java
@@ -1,0 +1,24 @@
+package org.example.fourtreesproject.companyRegVerify.model.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Table(name="company_reg_verify")
+@AllArgsConstructor
+@Getter
+@Builder
+public class CompanyRegVerify {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long idx;
+
+    @Column(nullable = false)
+    private String companyReg;
+    @Column(nullable = false)
+    private String uuid;
+}

--- a/project/src/main/java/org/example/fourtreesproject/companyRegVerify/model/request/CompanyRegVerifyRequest.java
+++ b/project/src/main/java/org/example/fourtreesproject/companyRegVerify/model/request/CompanyRegVerifyRequest.java
@@ -1,0 +1,16 @@
+package org.example.fourtreesproject.companyRegVerify.model.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.Date;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class CompanyRegVerifyRequest {
+    private String b_no;
+    private String p_nm;
+    private String start_dt;
+}

--- a/project/src/main/java/org/example/fourtreesproject/companyRegVerify/model/response/CompanyRegVerifyResponse.java
+++ b/project/src/main/java/org/example/fourtreesproject/companyRegVerify/model/response/CompanyRegVerifyResponse.java
@@ -1,0 +1,14 @@
+package org.example.fourtreesproject.companyRegVerify.model.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class CompanyRegVerifyResponse {
+    private String uuid;
+}

--- a/project/src/main/java/org/example/fourtreesproject/companyRegVerify/repository/CompanyRegVerifyRepository.java
+++ b/project/src/main/java/org/example/fourtreesproject/companyRegVerify/repository/CompanyRegVerifyRepository.java
@@ -1,0 +1,7 @@
+package org.example.fourtreesproject.companyRegVerify.repository;
+
+import org.example.fourtreesproject.companyRegVerify.model.entity.CompanyRegVerify;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CompanyRegVerifyRepository extends JpaRepository<CompanyRegVerify, Long> {
+}

--- a/project/src/main/java/org/example/fourtreesproject/companyRegVerify/service/CompanyRegVerifyService.java
+++ b/project/src/main/java/org/example/fourtreesproject/companyRegVerify/service/CompanyRegVerifyService.java
@@ -1,0 +1,103 @@
+package org.example.fourtreesproject.companyRegVerify.service;
+;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import lombok.RequiredArgsConstructor;
+import org.example.fourtreesproject.common.BaseResponse;
+import org.example.fourtreesproject.companyRegVerify.dto.CompanyRegVeriifyDto;
+import org.example.fourtreesproject.companyRegVerify.model.entity.CompanyRegVerify;
+import org.example.fourtreesproject.companyRegVerify.model.request.CompanyRegVerifyRequest;
+import org.example.fourtreesproject.companyRegVerify.model.response.CompanyRegVerifyResponse;
+import org.example.fourtreesproject.companyRegVerify.repository.CompanyRegVerifyRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+
+import org.springframework.web.client.RestTemplate;
+
+import static org.example.fourtreesproject.common.BaseResponseStatus.*;
+
+import java.util.*;
+
+
+@Service
+@RequiredArgsConstructor
+public class CompanyRegVerifyService {
+    @Value("${api.nts-businessman.v1.validate.serviceKey}")
+    private String serviceKey;
+    @Value("${api.nts-businessman.v1.validate.url}")
+    private String apiUrl;
+
+    private final CompanyRegVerifyRepository companyRegVerifyRepository;
+
+    // 사업자동륵번호 진위확인 API
+    private ResponseEntity<String> sendValidateApi(CompanyRegVerifyRequest companyRegVerifyRequest) {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("businesses", Collections.singletonList(
+                companyRegVerifyRequest
+        ));
+
+        Gson gson = new Gson();
+        String jsonPayload = gson.toJson(payload);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.CONTENT_TYPE, "application/json");
+        headers.add(HttpHeaders.AUTHORIZATION, "Infuser " + serviceKey);
+        HttpEntity<String> requestEntity = new HttpEntity<>(jsonPayload, headers);
+
+        RestTemplate restTemplate = new RestTemplate();
+        return restTemplate.exchange(
+                apiUrl,
+                HttpMethod.POST,
+                requestEntity,
+                String.class
+        );
+    }
+
+    // TODO : 예외처리
+    public BaseResponse verify(CompanyRegVerifyRequest companyRegVerifyRequest) {
+
+        ResponseEntity<String> response = sendValidateApi(companyRegVerifyRequest);
+
+        // 응답이 200 ok
+        if (response.getStatusCode().is2xxSuccessful()) {
+            Gson gson = new Gson();
+            JsonObject jsonObject = gson.fromJson(response.getBody(), JsonObject.class);
+
+            JsonArray dataArray = jsonObject.getAsJsonArray("data");
+            JsonObject dataObject = dataArray.get(0).getAsJsonObject();
+            String valid = dataObject.get("valid").getAsString();
+            String b_no = dataObject.get("b_no").getAsString();
+
+            if(valid.equals("01")) { // 일치할경우, valid: 01
+                return new BaseResponse<>(
+                        save(
+                            CompanyRegVeriifyDto.builder()
+                                    .uuid(UUID.randomUUID().toString())
+                                    .companyReg(b_no)
+                                    .build()
+                        )
+                );
+            }
+            else {
+                // 일치하지 않을 경우, valid: 02
+                return new BaseResponse<>(USER_BUSINESS_NUMBER_AUTH_FAIL);
+            }
+        } else {
+            return new BaseResponse<>(USER_BUSINESS_NUMBER_AUTH_FAIL);
+        }
+    }
+
+    public CompanyRegVerifyResponse save(CompanyRegVeriifyDto companyRegVeriifyDto) {
+        CompanyRegVerify companyRegVerify = CompanyRegVerify.builder()
+                .uuid(companyRegVeriifyDto.getUuid())
+                .companyReg(companyRegVeriifyDto.getCompanyReg())
+                .build();
+        companyRegVerifyRepository.save(companyRegVerify);
+
+        return CompanyRegVerifyResponse.builder()
+                .uuid(companyRegVerify.getUuid())
+                .build();
+    }
+}


### PR DESCRIPTION
사업자등록번호 인증 엔티티 생성
국세청_사업자등록정보 진위확인 서비스 사용
사업자등록번호 인증에 저장 후 uuid를 응답값으로 준다.