### PR TITLE
[Fix] 일반 회원 정보 상세 조회 시 사용할 수 없는 쿠폰은 조회 안되도록 수정 (#102)

### DIFF
--- a/project/src/main/java/org/example/fourtreesproject/user/service/UserService.java
+++ b/project/src/main/java/org/example/fourtreesproject/user/service/UserService.java
@@ -145,6 +145,9 @@ public class UserService {
     private List<CouponResponse> getCouponResponseList(User user) {
         List<CouponResponse> couponResponseList = new ArrayList<>();
         for (UserCoupon userCoupon : user.getUserCouponList()) {
+            if(!userCoupon.getCouponStatus()){
+                continue;
+            }
             Coupon coupon = userCoupon.getCoupon();
             CouponResponse couponResponse = CouponResponse.builder()
                     .couponContent(coupon.getCouponContent())


### PR DESCRIPTION
- 일반 회원 정보 상세 조회 시 사용할 수 없는 쿠폰은 조회 안되도록 수정 